### PR TITLE
Fix syntax and linting errors

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Ensure build prerequisites are installed
-  pacman: "name={{ item }} state=installed"
+  pacman:
+    name: "{{ item }}"
+    state: present
   with_items:
     - binutils
     - make
@@ -10,17 +12,16 @@
     - yajl
     - git
     - cower
-  
+
 - name: "Create {{ aur_build_user}} user"
   user:
     name: "{{ aur_build_user }}"
     append: true
     groups: wheel
     state: present
-  register: create_build_user
 
 - name: Check if pacaur is installed
-  command: 'pacman -Qi pacaur'
+  command: 'pacman -Q pacaur'
   failed_when: false
   changed_when: aur_pacaur_check.rc != 0
   register: aur_pacaur_check
@@ -32,7 +33,9 @@
   when: aur_pacaur_check.rc != 0
 
 - name: Install pacaur
-  command: "makepkg PKGBUILD --install --needed --noconfirm" chdir="~{{ aur_build_user }}/pacaur/"
+  command: "makepkg PKGBUILD --install --needed --noconfirm"
+  args:
+    chdir: "~{{ aur_build_user }}/pacaur/"
   become: true
   become_user: "{{ aur_build_user }}"
   notify: Cleanup pacaur build directory


### PR DESCRIPTION
Do the following:

* Fix a syntax error in the "Install pacaur" task.
* Use yaml syntax instead of Ansible's inline syntax in the following
  tasks:
  * Ensure build prerequisites are installed
  * Install pacaur
* Use `state: present` instead of `state: installed` in calls to the
  pacman module. The former argument is documented as being available
  and correct, and the latter isn't.
* Drop trailing whitespace.
* Call `pacman -Q $package` instead of `pacman -Qi $package`. Both can
  be used to check if a package is present, and the former spits out
  much less data (and should therefore be faster and more reliable).
* Drop an unused registered variable.

One can now run `ansible-lint .` in the root of the repository without
triggering any errors or warnings.