### PR TITLE
Fix downloading of pacaur

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
   register: aur_pacaur_check
 
 - name: Download pacaur
-  command: "cower -dqf --target=~{{ aur_build_user }}/ pacaur"
+  shell: "cower -dqf --target=$(eval echo ~{{ aur_build_user }}/) pacaur"
   become: true
   become_user: "{{ aur_build_user }}"
   when: aur_pacaur_check.rc != 0


### PR DESCRIPTION
The previous code didn't work for two reasons:
1. The command module doesn't interpret "~pacaur-builder"
2. Even when using the shell module, "~pacaur-builder" doesn't get expanded because there isn't white space before it.

This is the error I got:

```
fatal: [alarmpi]: FAILED! => {
    "changed": true,
    "cmd": "cower -dqf --target=~pacaur-builder/ pacaur",
    "delta": "0:00:00.141139", "end": "2017-09-28 20:32:33.139872",
    "failed": true,
    "msg": "non-zero return code",
    "rc": 1,
    "start": "2017-09-28 20:32:32.998733",
    "stderr": "error: cannot write to ~pacaur-builder/: No such file or directory",
    "stderr_lines": ["error: cannot write to ~pacaur-builder/: No such file or directory"],
    "stdout": "",
    "stdout_lines": []
}
```